### PR TITLE
Official support for webpack 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"
 
 env:
   - WEBPACK_VERSION=1
-  - WEBPACK_VERSION=beta
+  - WEBPACK_VERSION=2
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15",
+    "loader-utils": "^1.1.0",
     "lodash": "^4.14.1",
     "precond": "^0.2.3",
-    "webpack-sources": "^0.1.2"
+    "webpack-sources": "^0.2.3"
   },
   "nyc": {
     "include": [

--- a/src/shimLoader.js
+++ b/src/shimLoader.js
@@ -1,8 +1,8 @@
-import { getCurrentRequest, parseQuery } from 'loader-utils';
+import { getCurrentRequest, getOptions } from 'loader-utils';
 import transform from './transform';
 
 function getShim(loaderContext) {
-	const query = parseQuery(loaderContext.query);
+  const query = Object.assign({}, getOptions(loaderContext));
   const shim = query.shim || {};
 
   const moduleName = loaderContext._module.rawRequest;

--- a/test/test.js
+++ b/test/test.js
@@ -45,7 +45,7 @@ function testWebpack(webpackConfig, bundlePath, assertions, done) {
 
 describe('Shim Test Cases', function() {
   const casesPath = path.join(__dirname, 'shimCases');
-  const tmpPath = path.join('.tmp', 'shimCases');
+  const tmpPath = path.resolve('.tmp', 'shimCases');
   const bundleName = 'bundle.js';
 
 


### PR DESCRIPTION
Fixes #4 and adds support for webpack 2.

Note: the deprecation warning in the test logs comes from babel-loader. babel-loader 7 fixes this but drops support for webpack 1, but I would like to support webpack 1 as long as this does not need any extra effort.